### PR TITLE
fix link to 'installing nodejs', and fix article about install nodejs on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 
 ### Requirement
 
-[Node.js](https://nodejs.org/)が必要です。わからなければ[Node.jsの環境構築をする]()を参照してください。
+[Node.js](https://nodejs.org/)が必要です。わからなければ[Node.jsの環境構築をする](environment-setup/#f-nodejsをインストールしよう) を参照してください。
 
 ### Installation
 

--- a/environment-setup/index.md
+++ b/environment-setup/index.md
@@ -125,7 +125,7 @@ Pythonが使えると便利なことが多いので紹介しておく。
 
 #### Windows
 
-1. [node.jsのダウンロードページ](https://nodejs.org/ja/download/)からWindows Installerを選んで、.pkgファイルをダウンロード
+1. [node.jsのダウンロードページ](https://nodejs.org/ja/download/)からWindows Installerを選んで、.msiファイルをダウンロード
 2. ダウンロードしたインストーラーを開いて、ウィザードの指示に従ってインストールする
 3. Powershellかコマンドプロンプトを開いて、`node --help`と`npm help`の両方でヘルプ画面が出ればOK
 


### PR DESCRIPTION
 Fix README.md :
   node.js のインストール記事へのリンクを修正
Fix environment/index.md :
    Windows用のインストールの表記ミスを修正