### PR TITLE
ADD title of the wiki(alg-wiki) to book.json

### DIFF
--- a/book.json
+++ b/book.json
@@ -1,3 +1,4 @@
 {
+  "title": "alg-wiki",
   "plugins": ["katex"]
 }


### PR DESCRIPTION
book.jsonを変更し、<head>タグの<title>にalg-wikiという文言が追加されるようになりました